### PR TITLE
refactor: simplify slack webhook and utilities

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ import { uploadToGitHub, getCurrentJsonData } from './utils/github'
 
 const app = new Hono<{ Bindings: Bindings }>()
 
-
 /**
  * イベント処理用メインSlack Webhookエンドポイント
  */
@@ -13,106 +12,70 @@ app.post('/slack/events', async (c) => {
   const env = c.env
 
   try {
-
-    // 署名検証用ヘッダーを取得
-    const signature = c.req.header('X-Slack-Signature') ?? null
-    const timestamp = c.req.header('X-Slack-Request-Timestamp') ?? null
-
-    // 署名検証用にリクエストボディをテキストで取得
+    const signature = c.req.header('X-Slack-Signature') ?? ''
+    const timestamp = c.req.header('X-Slack-Request-Timestamp') ?? ''
     const bodyText = await c.req.text()
 
-    // セキュリティのためSlack署名を検証
-    const isValid = await verifySlackSignature(signature, timestamp, bodyText, env.SLACK_SIGNING_SECRET)
-    if (!isValid) {
+    if (!(await verifySlackSignature(signature, timestamp, bodyText, env.SLACK_SIGNING_SECRET))) {
       return c.text('Unauthorized', 401)
     }
 
-    // ボディテキストからJSONをパース
     let body: any
     try {
       body = JSON.parse(bodyText)
-    } catch (parseError) {
-      // Slackリトライメッセージかどうか確認
-      if (bodyText.includes('Request for Retry')) {
-        return c.text('OK')
-      }
-      return c.text('Invalid JSON', 400)
+    } catch {
+      return bodyText.includes('Request for Retry') ? c.text('OK') : c.text('Invalid JSON', 400)
     }
 
-  // Slack URL検証チャレンジを処理
-  if (body.type === 'url_verification') {
-    return c.text(body.challenge)
-  }
+    if (body.type === 'url_verification') {
+      return c.text(body.challenge)
+    }
 
-  // ファイル添付付きメッセージイベントを処理（ボットメッセージを除く）
-  if (body.event?.type === 'message' && !body.event.bot_id && body.event.files) {
     const event = body.event
-    const file = event.files[0]
+    const file = event?.files?.[0]
 
-    // 画像ファイルのみをフィルタ
-    if (!file.mimetype?.startsWith('image/')) {
+    if (!file || event.bot_id || event.type !== 'message' || !file.mimetype?.startsWith('image/')) {
       return c.text('OK')
     }
 
     try {
-      // メッセージテキストからメタデータを抽出
       const { title, date, url } = parseMessage(event.text || '')
 
-      // 必要な日付フォーマット（YYYY/MM/DD）を検証
       if (!/^\d{4}\/\d{2}\/\d{2}$/.test(date)) {
         await sendSlackMessage(env.SLACK_BOT_TOKEN, event.channel, event.ts, '❌ 日付は YYYY/MM/DD 形式で入力してください')
         return c.text('OK')
       }
 
-      // Slackから画像をダウンロード
       const imageBuffer = await getSlackFile(file.url_private_download, env.SLACK_BOT_TOKEN)
-
-      // タイムスタンプ付きファイル名とディレクトリ構造を生成
       const timestamp = Date.now()
-      const fileName = `${timestamp}_${file.name}`
       const [year, month] = date.split('/')
+      const fileName = `${timestamp}_${file.name}`
       const fullPath = `${year}/${month}/${fileName}`
 
-      // GitHubから現在のJSONデータを取得
       const currentData = await getCurrentJsonData(env)
-
-      // 新しいメタデータエントリを作成
-      const newId = currentData.length > 0 ? Math.max(...currentData.map(item => item.id)) + 1 : 1
+      const newId = currentData.length ? Math.max(...currentData.map(item => item.id)) + 1 : 1
       const newEntry: LabEntry = {
         id: newId,
         image: `/${env.IMAGE_PATH}${fullPath}`,
         title: title || '',
         datetime: date.replace(/\//g, '-'),
-        link: url || '',
+        link: url || ''
       }
 
-      // 新しいエントリを先頭に挿入（時間顺）
-      const updatedData = [newEntry, ...currentData]
-
-      // 画像とJSONの両方をGitHubにコミット
-      await uploadToGitHub(env, fullPath, imageBuffer, updatedData)
-
-      // 成功通知をSlackに送信
+      await uploadToGitHub(env, fullPath, imageBuffer, [newEntry, ...currentData])
       await sendSlackMessage(env.SLACK_BOT_TOKEN, event.channel, event.ts, `✅ アップロード完了: ${fileName}`)
-
     } catch (error) {
       console.error('Upload error:', error)
       const errorMessage = error instanceof Error ? error.message : 'Unknown error'
       const errorStack = error instanceof Error ? error.stack : undefined
-      
-      // 詳細なエラー情報を含めてSlackに送信
       let detailedError = `❌ エラー: ${errorMessage}`
       if (errorStack) {
-        // スタックトレースの最初の数行のみを含める（Slackのメッセージ制限を考慮）
         const stackLines = errorStack.split('\n').slice(0, 3)
         detailedError += `\n\`\`\`\n${stackLines.join('\n')}\n\`\`\``
       }
-
       await sendSlackMessage(env.SLACK_BOT_TOKEN, event.channel, event.ts, detailedError)
     }
-  }
 
-    // 常にSlackに200 OKを返す
     return c.text('OK')
   } catch (error) {
     console.error('Unexpected error in Slack webhook:', error)
@@ -124,6 +87,5 @@ app.post('/slack/events', async (c) => {
  * ヘルスチェックエンドポイント
  */
 app.get('/', (c) => c.text('OK'))
-
 
 export default app

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -14,16 +14,16 @@ export async function uploadToGitHub(
   jsonData: LabEntry[]
 ): Promise<void> {
   const { GITHUB_TOKEN, GITHUB_OWNER, GITHUB_REPO, GITHUB_BRANCH, IMAGE_PATH, JSON_PATH } = env
+  const authHeaders = {
+    Authorization: `token ${GITHUB_TOKEN}`,
+    'User-Agent': 'Slack-to-GitHub-Worker'
+  }
+  const jsonHeaders = { ...authHeaders, 'Content-Type': 'application/json' }
 
   // 現在のコミットSHAを取得
   const branchResp = await fetch(
     `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/git/refs/heads/${GITHUB_BRANCH}`,
-    {
-      headers: {
-        Authorization: `token ${GITHUB_TOKEN}`,
-        'User-Agent': 'Slack-to-GitHub-Worker'
-      }
-    }
+    { headers: authHeaders }
   )
 
   if (!branchResp.ok) {
@@ -38,12 +38,7 @@ export async function uploadToGitHub(
   // 現在のツリーを取得
   const commitResp = await fetch(
     `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/git/commits/${currentCommitSha}`,
-    {
-      headers: {
-        Authorization: `token ${GITHUB_TOKEN}`,
-        'User-Agent': 'Slack-to-GitHub-Worker'
-      }
-    }
+    { headers: authHeaders }
   )
 
   if (!commitResp.ok) {
@@ -60,11 +55,7 @@ export async function uploadToGitHub(
 
   const imageBlob = await fetch(`https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/git/blobs`, {
     method: 'POST',
-    headers: {
-      Authorization: `token ${GITHUB_TOKEN}`,
-      'Content-Type': 'application/json',
-      'User-Agent': 'Slack-to-GitHub-Worker'
-    },
+    headers: jsonHeaders,
     body: JSON.stringify({
       content: imageBase64,
       encoding: 'base64'
@@ -81,11 +72,7 @@ export async function uploadToGitHub(
 
   const jsonBlob = await fetch(`https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/git/blobs`, {
     method: 'POST',
-    headers: {
-      Authorization: `token ${GITHUB_TOKEN}`,
-      'Content-Type': 'application/json',
-      'User-Agent': 'Slack-to-GitHub-Worker'
-    },
+    headers: jsonHeaders,
     body: JSON.stringify({
       content: btoa(JSON.stringify(jsonData, null, 2)),
       encoding: 'base64'
@@ -103,11 +90,7 @@ export async function uploadToGitHub(
   // 新しいツリーを作成
   const newTree = await fetch(`https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/git/trees`, {
     method: 'POST',
-    headers: {
-      Authorization: `token ${GITHUB_TOKEN}`,
-      'Content-Type': 'application/json',
-      'User-Agent': 'Slack-to-GitHub-Worker'
-    },
+    headers: jsonHeaders,
     body: JSON.stringify({
       base_tree: currentTreeSha,
       tree: [
@@ -138,11 +121,7 @@ export async function uploadToGitHub(
   // コミットを作成
   const newCommit = await fetch(`https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/git/commits`, {
     method: 'POST',
-    headers: {
-      Authorization: `token ${GITHUB_TOKEN}`,
-      'Content-Type': 'application/json',
-      'User-Agent': 'Slack-to-GitHub-Worker'
-    },
+    headers: jsonHeaders,
     body: JSON.stringify({
       message: `Add lab image: ${fileName}`,
       tree: newTreeData.sha,
@@ -163,11 +142,7 @@ export async function uploadToGitHub(
     `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/git/refs/heads/${GITHUB_BRANCH}`,
     {
       method: 'PATCH',
-      headers: {
-        Authorization: `token ${GITHUB_TOKEN}`,
-        'Content-Type': 'application/json',
-        'User-Agent': 'Slack-to-GitHub-Worker'
-      },
+      headers: jsonHeaders,
       body: JSON.stringify({
         sha: newCommitData.sha
       })
@@ -188,16 +163,15 @@ export async function uploadToGitHub(
  */
 export async function getCurrentJsonData(env: Bindings): Promise<LabEntry[]> {
   const { GITHUB_TOKEN, GITHUB_OWNER, GITHUB_REPO, JSON_PATH, GITHUB_BRANCH } = env
+  const headers = {
+    Authorization: `token ${GITHUB_TOKEN}`,
+    'User-Agent': 'Slack-to-GitHub-Worker'
+  }
 
   try {
     const response = await fetch(
       `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/contents/${JSON_PATH}?ref=${GITHUB_BRANCH}`,
-      {
-        headers: {
-          Authorization: `token ${GITHUB_TOKEN}`,
-          'User-Agent': 'Slack-to-GitHub-Worker'
-        }
-      }
+      { headers }
     )
 
     if (response.status === 404) {
@@ -254,10 +228,7 @@ async function convertArrayBufferToBase64(content: ArrayBuffer): Promise<string>
   for (let i = 0; i < uint8Array.length; i += chunkSize) {
     const end = Math.min(i + chunkSize, uint8Array.length)
     for (let j = i; j < end; j++) {
-      const byte = uint8Array[j]
-      if (byte !== undefined) {
-        binaryString += String.fromCharCode(byte)
-      }
+      binaryString += String.fromCharCode(uint8Array[j])
     }
   }
 

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -228,7 +228,9 @@ async function convertArrayBufferToBase64(content: ArrayBuffer): Promise<string>
   for (let i = 0; i < uint8Array.length; i += chunkSize) {
     const end = Math.min(i + chunkSize, uint8Array.length)
     for (let j = i; j < end; j++) {
-      binaryString += String.fromCharCode(uint8Array[j])
+      if (typeof uint8Array[j] !== 'undefined') {
+        binaryString += String.fromCharCode(uint8Array[j])
+      }
     }
   }
 

--- a/src/utils/slack.ts
+++ b/src/utils/slack.ts
@@ -51,7 +51,7 @@ export function parseMessage(text: string): MessageMetadata {
   const metadata: MessageMetadata = { title: '', date: '', url: '' }
 
   for (const line of text.split('\n')) {
-    const match = line.trim().match(/^([a-z]+):\s*(.+)$/i)
+    const match = line.trim().match(/^([a-z]+):\s*(.*)$/i)
     if (!match) continue
     const key = match[1].toLowerCase()
     const value = match[2].trim()

--- a/src/utils/slack.ts
+++ b/src/utils/slack.ts
@@ -48,23 +48,30 @@ export async function verifySlackSignature(
  * @returns title、date、urlを含むオブジェクト
  */
 export function parseMessage(text: string): MessageMetadata {
-  const lines = text.split('\n')
-  let title = '', date = '', url = ''
+  const metadata: MessageMetadata = { title: '', date: '', url: '' }
 
-  // 各行をメタデータフィールドとしてパース
-  for (const line of lines) {
-    const trimmed = line.trim()
-    if (trimmed.startsWith('title:')) {
-      title = trimmed.substring(6).trim()
-    } else if (trimmed.startsWith('date:')) {
-      date = trimmed.substring(5).trim()
-    } else if (trimmed.startsWith('url:')) {
-      url = trimmed.substring(4).trim()
+  for (const line of text.split('\n')) {
+    const match = line.trim().match(/^([a-z]+):\s*(.+)$/i)
+    if (!match) continue
+    const key = match[1].toLowerCase()
+    const value = match[2].trim()
+
+    switch (key) {
+      case 'title':
+        metadata.title = value
+        break
+      case 'date':
+        metadata.date = value
+        break
+      case 'url':
+        metadata.url = value
+        break
     }
   }
 
-  return { title, date, url }
+  return metadata
 }
+
 
 /**
  * ボットトークンを使用してSlackからファイルをダウンロード
@@ -76,6 +83,9 @@ export async function getSlackFile(fileUrl: string, token: string): Promise<Arra
   const response = await fetch(fileUrl, {
     headers: { Authorization: `Bearer ${token}` }
   })
+  if (!response.ok) {
+    throw new Error(`Failed to fetch file: ${response.status}`)
+  }
   return response.arrayBuffer()
 }
 


### PR DESCRIPTION
## Summary
- streamline Slack webhook handler with early returns
- modernize Slack helpers and add fetch error handling
- consolidate GitHub API headers and tidy base64 conversion
- clarify message parsing and reuse GitHub JSON headers

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ed5a5e4c832db8f0ede7571864c2